### PR TITLE
Do not override already configured options

### DIFF
--- a/lib/cjs/logger.js
+++ b/lib/cjs/logger.js
@@ -42,7 +42,7 @@ function logger(requestedConfig) {
     if (requestedConfig) {
         exports.config = sessionSample_1.sessionSample(Object.assign(Object.assign({}, defaultConfig), requestedConfig));
     }
-    else {
+    else if (exports.config === undefined) {
         exports.config = defaultConfig;
     }
     state_1.clearState();

--- a/lib/es/logger.js
+++ b/lib/es/logger.js
@@ -41,7 +41,7 @@ export function logger(requestedConfig) {
     if (requestedConfig) {
         config = sessionSample(Object.assign(Object.assign({}, defaultConfig), requestedConfig));
     }
-    else {
+    else if (config === undefined) {
         config = defaultConfig;
     }
     clearState();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-log",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "A logging framework for AWS Lambda",
   "license": "MIT",
   "repository": "https://github.com/inocan-group/aws-log",

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -48,14 +48,18 @@ const defaultConfigs: IDictionary<IAwsLogConfig> = {
 export function logger(requestedConfig?: Partial<IAwsLogConfig>) {
   const environment = process.env.AWS_STAGE || "dev";
   const defaultConfig = defaultConfigs[environment];
+
   if (requestedConfig) {
     config = sessionSample({ ...defaultConfig, ...requestedConfig });
-  } else {
-    config = defaultConfig;
   }
+  else if (config === undefined) {
+    config = defaultConfig
+  } 
+
   clearState();
   initSeverity();
   setCorrelationId(createCorrelationId());
 
   return { ...loggingApi, ...contextApi };
 }
+


### PR DESCRIPTION
If the user configured the logger by env defaults options or passing options, the global logger's `config` variable should be preserved.