### PR TITLE
Add support not existing stage name

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -47,7 +47,7 @@ const defaultConfigs: IDictionary<IAwsLogConfig> = {
 
 export function logger(requestedConfig?: Partial<IAwsLogConfig>) {
   const environment = process.env.AWS_STAGE || "dev";
-  const defaultConfig = defaultConfigs[environment];
+  const defaultConfig = environment in defaultConfigs ? defaultConfigs[environment] : defaultConfigs["dev"];
   if (requestedConfig) {
     config = sessionSample({ ...defaultConfig, ...requestedConfig });
   } else {

--- a/test/logger-spec.ts
+++ b/test/logger-spec.ts
@@ -159,6 +159,21 @@ describe("Logger Basics", () => {
       expect(ctx[prop]).to.be.a("string");
     });
   });
+
+  it("Using random stage should use dev stage defaultConfig", () => {
+    process.env.AWS_STAGE = "dev";
+    const log = logger().lambda(lambdaEvent, lambdaContext, { baz: "test" }); 
+    const infoLogResult = log.info("Test line")
+    const debugLogResult = log.debug("Test line")
+    const warnLogResult = log.warn("Test line")
+    const errorLogResult = log.error("Test line")
+    
+
+    expect(infoLogResult).to.not.be.undefined
+    expect(debugLogResult).to.not.be.undefined
+    expect(warnLogResult).to.not.be.undefined
+    expect(errorLogResult).to.not.be.undefined
+  })
 });
 
 function testLoggingApi(api: any) {


### PR DESCRIPTION
Current implementation gives you errors if you use other than "dev", "stage", "test" and "production"

```
{
"errorType": "aws-orchestrate/error-handling",
    "errorMessage": "There was an error in the wrapper function while TRYING to handle another error. The original error had a message of: \n\"no message\".\n\nSubsequently the error within the wrapper function was: \"no message\""
{
```